### PR TITLE
Fix raindrops going through collision surface

### DIFF
--- a/Engine/source/T3D/fx/precipitation.cpp
+++ b/Engine/source/T3D/fx/precipitation.cpp
@@ -1283,7 +1283,7 @@ void Precipitation::interpolateTick(F32 delta)
       else
          curr->renderPosition = curr->position + windVel / curr->mass;
 
-      curr->renderPosition.z -= dt * curr->velocity;
+      //curr->renderPosition.z -= dt * curr->velocity;
 
       curr = curr->next;
    }


### PR DESCRIPTION
Usually pretty hard to notice. Raindrops created by the Precipitation object go through the surfaces they hit (just a little) before they actually disappear. Can most easily see the issue looking through camera's viewport just beneath surface level of a GroundPlane or WaterPlane while drops are colliding with the ground/water. 

I first noticed it when I needed a ceiling to be glass(transparent) and raindrops were coming into the ceiling. I needed absolute precision on the drops so they weren't creating visual eyesores inside the structure.

Removing the additional calculation on the current drop's z position fixes drops going through surfaces they collide with.
