### PR TITLE
Fix raindrop flickering

### DIFF
--- a/Engine/source/T3D/fx/precipitation.cpp
+++ b/Engine/source/T3D/fx/precipitation.cpp
@@ -1838,25 +1838,26 @@ void Precipitation::renderObject(ObjectRenderInst *ri, SceneRenderState *state, 
       tc++;
       vertPtr++;
 
-      // Do we need to flush the buffer by rendering?
+      // Flush the buffer by rendering.
       vertCount += 4;
-      if ( (vertCount + 4) >= mRainVB->mNumVerts ) {
-
+      //if ( (vertCount + 4) >= mRainVB->mNumVerts ) {
          mRainVB.unlock();
          GFX->drawIndexedPrimitive(GFXTriangleList, 0, 0, vertCount, 0, vertCount / 2);
          vertPtr = NULL;
          vertCount = 0;
-      }
+      //}
 
       curr = curr->nextSplashDrop;
    }
 
+   /*
    // Do we have stuff left to render?
    if ( vertCount > 0 ) {
 
       mRainVB.unlock();
       GFX->drawIndexedPrimitive(GFXTriangleList, 0, 0, vertCount, 0, vertCount / 2);
    }
+   */
 
    mLastRenderFrame = ShapeBase::sLastRenderFrame;
 


### PR DESCRIPTION
Okay changed this up a bit to remedy raindrop flickering, here's the deal:

The current behavior when rendering splashes is to keep filling the VB and flushing it as it gets full. This all occurs within a loop, and directly following that loop is another check if the VB has any 'leftover' stuff to render. What appears to be happening at runtime is the check in the loop to see if the buffer needs to be flushed keeps returning false or some other sorcery that forces the 'follow-up' check for leftover stuff to always find it.

In the end, since all of this is occurring within a rendering function it's constantly rendering out all of these 'leftover' splashes. The problem is by the time they are actually rendered the drop that they represent has already 'rolled' over. Since a drop that has become a splash isn't removed but instead is rolled back to the top, we get raindrops falling and trying to render splashes - hence flickering z fighting on falling drops.

Removing check for max verts in the main splash rendering loop and removing the check for leftover splashes after the main loop has finished appears to fix the flickering.
