### PR TITLE
Extend Collision struct

### DIFF
--- a/Engine/source/collision/collision.h
+++ b/Engine/source/collision/collision.h
@@ -60,6 +60,7 @@ struct Collision
    U32 face;                  // Which face was hit
    F32 faceDot;               // -Dot of face with poly normal
    F32 distance;
+   U32 index;                 // Index of sub-object hit within object
    
    Collision() :
       object( NULL ),

--- a/Engine/source/scene/sceneContainer.cpp
+++ b/Engine/source/scene/sceneContainer.cpp
@@ -1641,9 +1641,9 @@ DefineEngineFunction( containerRayCast, const char*,
    char *returnBuffer = Con::getReturnBuffer(bufSize);
    if(ret)
    {
-      dSprintf(returnBuffer, bufSize, "%d %g %g %g %g %g %g %g",
+      dSprintf(returnBuffer, bufSize, "%d %g %g %g %g %g %g %g %d", // added %d (extend collision struct)
                ret, rinfo.point.x, rinfo.point.y, rinfo.point.z,
-               rinfo.normal.x, rinfo.normal.y, rinfo.normal.z, rinfo.distance);
+               rinfo.normal.x, rinfo.normal.y, rinfo.normal.z, rinfo.distance, rinfo.index); // added rinfo.index (extend collision struct)
    }
    else
    {


### PR DESCRIPTION
Here the Collision struct is extended to add an index variable. This variable could potentially be used in several ways. 

One of the best uses for this variable is to use it to store an id for 'sub-objects' hit within an object. i.e. If a raycast hits a model that has several sub-meshes the id of the sub-mesh within the parent model can be stored. 

Then from script, we can use:

getWord( %raycast, 8 )

...to easily retrieve the stored id of the mesh that was hit with the raycast.
